### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/AllenDang/volcengine-rs/compare/v0.1.0...v0.1.1) - 2025-02-20
+
+### Other
+
+- Refine README and add CHANGELOG
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volcengine-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volcengine-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Volcengine API SDK"
 categories = ["authentication", "network-programming"]


### PR DESCRIPTION



## 🤖 New release

* `volcengine-rs`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/AllenDang/volcengine-rs/compare/v0.1.0...v0.1.1) - 2025-02-20

### Other

- Refine README and add CHANGELOG
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).