### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/AllenDang/volcengine-rs/compare/v0.1.1...v0.1.2) - 2025-02-20
+
+### Other
+
+- Delete redundant content in CHANGELOG
+
 ## [0.1.1](https://github.com/AllenDang/volcengine-rs/compare/v0.1.0...v0.1.1) - 2025-02-20
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volcengine-rs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volcengine-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Volcengine API SDK"
 categories = ["authentication", "network-programming"]


### PR DESCRIPTION



## 🤖 New release

* `volcengine-rs`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/AllenDang/volcengine-rs/compare/v0.1.1...v0.1.2) - 2025-02-20

### Other

- Delete redundant content in CHANGELOG
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).